### PR TITLE
Changed robots.txt

### DIFF
--- a/app/web/robots.txt
+++ b/app/web/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+Disallow: /?search[query]=*
+Disallow: /?search%5Bquery%5D=*


### PR DESCRIPTION
Запрет индексирования результатов поиска.
На данный момент яндекс проиндексировал помимо главной страницы ещё несколько страниц с результатами поиска

Думаю надо это убрать и запретить индексировать результаты

<details><summary>Скриншот яндекс вебмастера</summary>
<p>

![2023-07-14_00-35-07](https://github.com/terratensor/kob-library-app/assets/10896447/e05f1521-6c4a-44d2-921f-b6c393387c28)


</p>
</details> 

Главная страница сайта доступна для поиска: [поиск по толстым книгам](https://yandex.ru/search/?text=%D0%BF%D0%BE%D0%B8%D1%81%D0%BA+%D0%BF%D0%BE+%D1%82%D0%BE%D0%BB%D1%81%D1%82%D1%8B%D0%BC+%D0%BA%D0%BD%D0%B8%D0%B3%D0%B0%D0%BC&lr=2) 