### PR TITLE
Хлебные крошки включены

### DIFF
--- a/app/views/site/index.php
+++ b/app/views/site/index.php
@@ -22,7 +22,7 @@ use yii\data\Pagination;
 $this->title = Yii::$app->name;
 $this->params['meta_description'] = 'Поиск по текстам толстых книг ВП СССР. Поиск реализуется внутри содержания отдельного параграфа, включая сноски, если они есть';
 
-// $this->params['breadcrumbs'][] = 'Поиск по толстым книгам';
+$this->params['breadcrumbs'][] = 'Поиск по толстым книгам';
 
 $this->registerMetaTag(['property' => 'og:url', 'content' => Yii::$app->urlManager->createAbsoluteUrl('/')]);
 $this->registerMetaTag(['property' => 'og:type', 'content' => 'website']);


### PR DESCRIPTION
Пока надо оставить, без них на главной может быть непонятно, где находиться пользователь, но это не точно
второе, уплывает кнопка короткой ссылки влево. Требуется исправление. Пока вернул хлебные крошки